### PR TITLE
FIXED: Critical error during index construction

### DIFF
--- a/code/MSSQLDatabase.php
+++ b/code/MSSQLDatabase.php
@@ -858,7 +858,7 @@ class MSSQLDatabase extends SS_Database {
 			}
 
 			if($indexSpec['type'] == 'unique') {
-				if(!is_array($indexSpec['value'])) $columns = preg_split('/ *, */', trim($indexSpec['value']));
+				if(!is_array($indexSpec['value'])) $columns = preg_split('/"? *, *"?/', trim(trim($indexSpec['value']), '"'));
 				else $columns = $indexSpec['value'];
 				$SQL_columnList = '"' . implode('", "', $columns) . '"';
 


### PR DESCRIPTION
Indexes specified on dataobjects with quotes would crash the database during dev build. MS Sql database assumed that columns were unquoted, and subsequently quotes them during index creation.

In fact, any already quoted index spec would end up double quoted. See below for an example.

In Versioned.php

``` PHP
$versionIndexes = array_merge(
    array(
        'RecordID_Version' => array('type' => 'unique', 'value' => '"RecordID","Version"'),
        'RecordID' => true,
        'Version' => true,
    ),
    (array)$indexes
);
```

Which MS SQL Server module would turn into

``` SQL

CREATE UNIQUE INDEX ix_Page_versions_RecordID_Version ON "Page_versions" (""RecordID"", ""Version""); 
```
