### PR TITLE
FIXED: Paging issue in full text search results.

### DIFF
--- a/code/MSSQLDatabase.php
+++ b/code/MSSQLDatabase.php
@@ -1399,6 +1399,7 @@ class MSSQLDatabase extends SS_Database {
 		$list->setPageStart($start);
 		$list->setPageLength($pageLength);
 		$list->setTotalItems($current+1);
+		$list->setLimitItems(false); // We have limited the search results above
 		return $list;
 	}
 


### PR DESCRIPTION
In fulltext search results pages beyond the first would show no items. This is becuase the SQL Server fulltext search engine populates the PaginatedList object slightly differently to the MySQL engine (only creating the objects visible in the current page). A flag should have been set on the list to note this, but it was not.

I will plan on writing some more test cases in the near future for this module. :) I need a few days I think.
