### PR TITLE
Removing paging subset occuring before pagination is set

### DIFF
--- a/code/MSSQLDatabase.php
+++ b/code/MSSQLDatabase.php
@@ -1418,11 +1418,7 @@ class MSSQLDatabase extends SS_Database {
 		$objects = array();
 		foreach ($result as $row) {
 			$current++;
-
-			// Select a subset for paging
-			if ($current >= $start && $current < $start + $pageLength) {
-				$objects[] = DataObject::get_by_id($row['Source'], $row['ID']);
-			}
+			$objects[] = DataObject::get_by_id($row['Source'], $row['ID']);
 		}
 
 		if(isset($objects)) $results = new ArrayList($objects);


### PR DESCRIPTION
This was causing site search in mssql to only return one page of results
