### PR TITLE
BUG: Indexes were not being fully escaped 

### DIFF
--- a/code/MSSQLDatabase.php
+++ b/code/MSSQLDatabase.php
@@ -924,6 +924,7 @@ class MSSQLDatabase extends SS_Database {
 		
 		// Cleanup names of namespaced tables
 		$tableName = str_replace('\\', '_', $tableName);
+		$indexName = str_replace('\\', '_', $indexName);
 		
 		return "{$prefix}_{$tableName}_{$indexName}";
 	}


### PR DESCRIPTION
This fix enhances the namespace escaping to cover the entire index. Previously the parent table name was being escaped, but if the relational table was also to a namespaced class then it would trigger an error.
