### PR TITLE
Alias master as 1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,18 +4,21 @@
 	"type": "silverstripe-module",
 	"keywords": ["silverstripe", "mssql", "database"],
 	"authors": [
-	{
-		"name": "Sam Minnee",
-		"email": "sam@silverstripe.com"
-	},
-	{
-		"name": "Sean Harvey",
-		"email": "sean@silverstripe.com"
-	}
+		{
+			"name": "Sam Minnee",
+			"email": "sam@silverstripe.com"
+		},
+		{
+			"name": "Sean Harvey",
+			"email": "sean@silverstripe.com"
+		}
 	],
-
-	"require":
-	{
+	"require": {
 		"silverstripe/framework": "~3.2"
+	},
+	"extra": {
+		"branch-alias": {
+			"dev-master": "1.0.x-dev"
+		}
 	}
 }


### PR DESCRIPTION
Since we prefer users to not use 'dev-master' in composer.json, it's a better idea to give them a version constraint as an alias for this instead.

cc @simonwelsh
