### PR TITLE
Fixing use of "bigint" and "decimal" for pure integer types.

### DIFF
--- a/code/MSSQLSchemaManager.php
+++ b/code/MSSQLSchemaManager.php
@@ -438,12 +438,13 @@ class MSSQLSchemaManager extends DBSchemaManager {
 			// Update the data_type field to be a complete column definition string for use by
 			// SS_Database::requireField()
 			switch($field['data_type']){
+				case 'int':
 				case 'bigint':
 				case 'numeric':
 				case 'float':
 				case 'bit':
-					if($field['data_type'] != 'bigint' && $sizeSuffix = $field['numeric_precision']) {
-							$field['data_type'] .= "($sizeSuffix)";
+					if($field['data_type'] != 'bigint' && $field['data_type'] != 'int' && $sizeSuffix = $field['numeric_precision']) {
+						$field['data_type'] .= "($sizeSuffix)";
 					}
 
 					if($field['is_nullable'] == 'YES') {
@@ -729,8 +730,7 @@ class MSSQLSchemaManager extends DBSchemaManager {
 	 * @return string
 	 */
 	public function int($values) {
-		//We'll be using an 8 digit precision to keep it in line with the serial8 datatype for ID columns
-		return 'numeric(8) not null default ' . (int) $values['default'];
+		return 'int not null default ' . (int) $values['default'];
 	}
 
 	/**
@@ -788,17 +788,15 @@ class MSSQLSchemaManager extends DBSchemaManager {
 
 	/**
 	 * This returns the column which is the primary key for each table
-	 * In Postgres, it is a SERIAL8, which is the equivalent of an auto_increment
-	 *
 	 * @return string
 	 */
 	function IdColumn($asDbValue = false, $hasAutoIncPK = true){
 		if($asDbValue) {
-			return 'bigint not null';
+			return 'int not null';
 		} else if($hasAutoIncPK) {
-			return 'bigint identity(1,1)';
+			return 'int identity(1,1)';
 		} else {
-			return 'bigint not null';
+			return 'int not null';
 		}
 	}
 


### PR DESCRIPTION
See silverstripe#14 for more info.

"bigint" doesn't work for PHP 32-bit, as the integer could get too big
for PHP to be able to interpret the value as an integer type. In that
case it would try to approximate it as a float, but that could lead
to a bad assumption for identity columns.

For compatibility, stick with standard "int" type which has a maximum
value of 2147483647.

Note that MySQLAdapter already has this maximum, so changing it to
this keeps this database adapter consistent with MySQL.

Another PR for backporting to 3.0/3.1 compatible version was raised here: https://github.com/silverstripe/silverstripe-mssql/pull/16
