### PR TITLE
FIX Do not attempt to search non-existent classes

### DIFF
--- a/code/MSSQLDatabase.php
+++ b/code/MSSQLDatabase.php
@@ -1444,6 +1444,9 @@ class MSSQLDatabase extends SS_Database {
 
 		// Create one query per each table, $columns not used. We want just the ID and the ClassName of the object from this query.
 		foreach($tables as $tableName=>$columns){
+			// Don't bother trying to do things if the class doesn't actually exist
+			if (!class_exists($tableName)) continue;
+
 			$baseClass = ClassInfo::baseDataClass($tableName);
 
 			$join = $this->fullTextSearchMSSQL($tableName, $keywords);


### PR DESCRIPTION
Previously, if there was a table that was searchable by MSSQL but didn't exist in SilverStripe, the `searchEngine` function would throw an Exception.

This will need to be merged up into master too.