### PR TITLE
Add Appveyor test configuration for Windows-based CI

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,42 @@
+build: false
+shallow_clone: false
+platform: 'x86'
+clone_folder: C:\projects\silverstripe
+
+services:
+  - mssql2014
+
+before_test:
+  - sqlcmd -S "(local)\SQL2014" -Q "Use [master]; CREATE DATABASE [appveyor]"
+  - SET PATH=C:\Program Files\OpenSSL;C:\tools\php;%PATH%
+  - cinst -y php -version 5.6.11
+  - cd c:\tools\php
+  - ps: cat php.ini-production | %{$_ -replace "memory_limit = 128M","memory_limit = 256M"} | Out-File -Encoding "Default" php.ini
+  - echo date.timezone="UTC" >> php.ini
+  - echo extension_dir=ext >> php.ini
+  - echo extension=php_openssl.dll >> php.ini
+  - echo extension=php_mbstring.dll >> php.ini
+  - echo extension=php_curl.dll >> php.ini
+  - echo extension=php_gd2.dll >> php.ini
+  - echo extension=php_tidy.dll >> php.ini
+  - php -r "readfile('http://getcomposer.org/installer');" | php
+  - php -r "readfile('https://dl.dropboxusercontent.com/u/7129062/sqlsrv_unofficial_3.0.2.2.zip');" > sqlsrv.zip
+  - unzip sqlsrv.zip
+  - copy sqlsrv_unofficial_3.0.2.2\x64\*.dll ext
+  - echo extension=php_sqlsrv_56_nts.dll >> php.ini
+  - echo extension=php_pdo_sqlsrv_56_nts.dll >> php.ini
+  - ps: echo "php c:\tools\php\composer.phar %*" | Out-File -Encoding "Default" composer.bat
+  - type composer.bat
+  - composer --version
+  - git clone --branch=windows-support git://github.com/silverstripe-labs/silverstripe-travis-support.git c:\projects\travis-support
+  - php c:\projects\travis-support\travis_setup.php --source c:\projects\silverstripe --target c:\projects\assembled
+  - cd c:\projects\assembled
+
+test_script:
+  - cd c:\projects\assembled
+  - ps: cat phpunit.xml.dist | %{$_ -replace "colors=\"true\"","colors=\"false\""} | Out-File -Encoding "Default" phpunit.xml.dist
+  - php .\vendor\phpunit\phpunit\composer\bin\phpunit framework/tests
+
+environment:
+  DB: MSSQL
+  CORE_RELEASE: 3

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Allows SilverStripe to use SQL Server databases.
 
+[![Build status](https://ci.appveyor.com/api/projects/status/hep0l5kbhu64n7l3/branch/master?svg=true)](https://ci.appveyor.com/project/sminnee/silverstripe-mssql-nwvfq/branch/master)
+
 ## Maintainer Contact
 
  * Sean Harvey (Nickname: halkyon)

--- a/composer.json
+++ b/composer.json
@@ -20,5 +20,7 @@
 		"branch-alias": {
 			"dev-master": "1.0.x-dev"
 		}
-	}
+	},
+	"prefer-stable": true,
+	"minimum-stability": "dev"
 }


### PR DESCRIPTION
We can't use Travis for our Windows testing, so I have configured this
test run for Appveyor. It will run Windows + MSSQL!

You can see a sample run here:
https://ci.appveyor.com/project/sminnee/silverstripe-mssql/build/1.0.6

We've got failing tests, but my understanding is that these are legitimate test failures that I wanted to expose.

Once we've got the tests fixed, then I'd like to add this as a build configuration to the main framework matrix, but for now we can run it against this module.

Once this is merged, the AppVeyor builds should start—I've configured `silverstripe/silverstripe-mssql` to build any branch that has a .appveyor.yml file.