### PR TITLE
Update connectors.yml

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,29 @@
+BSD 3-Clause License
+
+Copyright (c) 2018, SilverStripe Ltd.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/_config/connectors.yml
+++ b/_config/connectors.yml
@@ -6,23 +6,23 @@ SilverStripe\Core\Injector\Injector:
   MSSQLPDODatabase:
     class: 'SilverStripe\MSSQL\MSSQLDatabase'
     properties:
-      connector: %$PDOConnector
-      schemaManager: %$MSSQLSchemaManager
-      queryBuilder: %$MSSQLQueryBuilder
+      connector: '%$PDOConnector'
+      schemaManager: '%$MSSQLSchemaManager'
+      queryBuilder: '%$MSSQLQueryBuilder'
 # Uses sqlsrv_connect
   MSSQLDatabase:
     class: 'SilverStripe\MSSQL\MSSQLDatabase'
     properties:
-      connector: %$SQLServerConnector
-      schemaManager: %$MSSQLSchemaManager
-      queryBuilder: %$MSSQLQueryBuilder
+      connector: '%$SQLServerConnector'
+      schemaManager: '%$MSSQLSchemaManager'
+      queryBuilder: '%$MSSQLQueryBuilder'
 # Uses sqlsrv_connect to connect to a MS Azure Database
   MSSQLAzureDatabase:
     class: 'SilverStripe\MSSQL\MSSQLAzureDatabase'
     properties:
-      connector: %$SQLServerConnector
-      schemaManager: %$MSSQLSchemaManager
-      queryBuilder: %$MSSQLQueryBuilder
+      connector: '%$SQLServerConnector'
+      schemaManager: '%$MSSQLSchemaManager'
+      queryBuilder: '%$MSSQLQueryBuilder'
   SQLServerConnector:
     class: 'SilverStripe\MSSQL\SQLServerConnector'
     type: prototype

--- a/code/SQLServerQuery.php
+++ b/code/SQLServerQuery.php
@@ -43,13 +43,21 @@ class SQLServerQuery extends Query
         }
     }
 
-    public function seek($row)
+    public function getIterator()
     {
-        if (!is_resource($this->handle)) {
-            return false;
-        }
+        if (is_resource($this->handle)) {
+            while ($data = sqlsrv_fetch_array($this->handle, SQLSRV_FETCH_ASSOC)) {
+                // special case for sqlsrv - date values are DateTime coming out of the sqlsrv drivers,
+                // so we convert to the usual Y-m-d H:i:s value!
+                foreach ($data as $name => $value) {
+                    if ($value instanceof DateTime) {
+                        $data[$name] = $value->format('Y-m-d H:i:s');
+                    }
+                }
 
-        user_error('MSSQLQuery::seek() not supported in sqlsrv', E_USER_WARNING);
+                yield $data;
+            }
+        }
     }
 
     public function numRecords()
@@ -64,29 +72,5 @@ class SQLServerQuery extends Query
         } else {
             user_error('MSSQLQuery::numRecords() not supported in this version of sqlsrv', E_USER_WARNING);
         }
-    }
-
-    public function nextRecord()
-    {
-        if (!is_resource($this->handle)) {
-            return false;
-        }
-
-        if ($data = sqlsrv_fetch_array($this->handle, SQLSRV_FETCH_ASSOC)) {
-            // special case for sqlsrv - date values are DateTime coming out of the sqlsrv drivers,
-            // so we convert to the usual Y-m-d H:i:s value!
-            foreach ($data as $name => $value) {
-                if ($value instanceof DateTime) {
-                    $data[$name] = $value->format('Y-m-d H:i:s');
-                }
-            }
-            return $data;
-        } else {
-            // Free the handle if there are no more results - sqlsrv crashes if there are too many handles
-            sqlsrv_free_stmt($this->handle);
-            $this->handle = null;
-        }
-
-        return false;
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
 	},
 	"extra": {
 		"branch-alias": {
-			"dev-master": "2.x-dev"
+			"dev-master": "3.x-dev"
 		}
 	},
 	"autoload": {


### PR DESCRIPTION
Not quoting a scalar starting with the "%" indicator character has been deprecated since Symfony 3.1 and throws a ParseException in 4.0 and above.
https://docs.silverstripe.org/en/4/changelogs/4.7.0/#support-for-symfony-4-components